### PR TITLE
Proposal - Pass in environment directly to `runCbAuthT`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ run Sandbox (trades (ProductId "BTC-USD")) >>= print
 ### Authenticated Private Requests
 
 ```haskell
-runCbAuthT (run Sandbox) cpc $ do
+runCbAuthT Sandbox cpc $ do
     fills (Just btcusd) Nothing >>= liftIO . print
   where
     accessKey  = CBAccessKey "<access-key>"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Version 0.9.3.0
+
+- Pass desired environment into `runCbAuthT`.
+
 # Version 0.9.2.0
 
 Feature complete! (except FIX)

--- a/coinbase-pro.cabal
+++ b/coinbase-pro.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0482a3909f589fcef459af8d11acc45ae48f1918d4659454f25b36f471e2764d
+-- hash: 39117a5fc666381034957c3be8b32eaffe43cbd7ef32d749aaf7922993780458
 
 name:           coinbase-pro
-version:        0.9.1.0
+version:        0.9.3.0
 synopsis:       Client for Coinbase Pro
 description:    Client for Coinbase Pro REST and Websocket APIs
 category:       Web, Finance

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:           coinbase-pro
-version:        0.9.2.0
+version:        0.9.3.0
 description:    Client for Coinbase Pro REST and Websocket APIs
 homepage:       https://github.com/mdunnio/coinbase-pro#readme
 bug-reports:    https://github.com/mdunnio/coinbase-pro/issues

--- a/src/example/request/Main.hs
+++ b/src/example/request/Main.hs
@@ -26,7 +26,7 @@ main = do
     run Sandbox (aggregateOrderBook btcusd (Just Best)) >>= print
     run Sandbox (aggregateOrderBook btcusd (Just TopFifty)) >>= print
     run Sandbox (fullOrderBook btcusd) >>= print
-    runCbAuthT (run Sandbox) cpc $ do
+    runCbAuthT Sandbox cpc $ do
         accounts >>= liftIO . print
         account aid >>= liftIO . print
         accountHistory aid >>= liftIO . print

--- a/src/lib/CoinbasePro/Authenticated/Request.hs
+++ b/src/lib/CoinbasePro/Authenticated/Request.hs
@@ -51,7 +51,8 @@ import           CoinbasePro.Authenticated.Headers (CBAccessKey (..),
                                                     CBAccessSign (..),
                                                     CBAccessTimeStamp (..))
 import           CoinbasePro.Headers               (userAgent)
-import           CoinbasePro.Request               (Body, RequestPath, Runner)
+import           CoinbasePro.Request               (Body, RequestPath, run)
+import CoinbasePro.Environment (Environment)
 
 
 newtype CBSecretKey = CBSecretKey String
@@ -69,8 +70,8 @@ newtype CBAuthT m a = CBAuthT { unCbAuth :: ReaderT CoinbaseProCredentials m a }
     deriving (Functor, Applicative, Monad, MonadIO, MonadTrans)
 
 
-runCbAuthT :: Runner a -> CoinbaseProCredentials -> CBAuthT ClientM a -> IO a
-runCbAuthT runEnv cpc = runEnv . flip runReaderT cpc . unCbAuth
+runCbAuthT :: Environment -> CoinbaseProCredentials -> CBAuthT ClientM a -> IO a
+runCbAuthT env cpc = run env . flip runReaderT cpc . unCbAuth
 
 
 type instance AuthClientData (AuthProtect "CBAuth") = (CBAccessKey, CBAccessSign, CBAccessTimeStamp, CBAccessPassphrase)

--- a/src/lib/CoinbasePro/Request.hs
+++ b/src/lib/CoinbasePro/Request.hs
@@ -15,8 +15,6 @@ module CoinbasePro.Request
     , run_
     , runWithManager
 
-    , Runner
-
     , emptyBody
     , encodeRequestPath
     ) where
@@ -47,10 +45,6 @@ type RequestPath = ByteString
 
 -- ^ Serialized as a part of building CBAccessSign
 type Body        = ByteString
-
-
-type Runner a = ClientM a -> IO a
-
 
 ------------------------------------------------------------------------------
 -- | Runs a coinbase pro HTTPS request and returns the result `a`


### PR DESCRIPTION
Hi - thank you very much for this library. Literally the day before you posted this on `/r/haskell`, I had pushed a Rails app to Heroku because Rails had a gem, while Haskell didn't have a package.

Anyway, I had an idea I wanted to run by you. I don't think there is any other useful thing that a client of `runCbAuthT` can do except pass in `run Production` or `run Sandbox`, so I thought it might make more sense to pass in the environment directly instead of a function. I think it makes the type clearer, and it would avoid someone reimplementing their own `run`, as I'm likely to do.