### PR TITLE
support stop orders by exposing PlaceOrderBody

### DIFF
--- a/src/lib/CoinbasePro/Authenticated.hs
+++ b/src/lib/CoinbasePro/Authenticated.hs
@@ -11,6 +11,7 @@ module CoinbasePro.Authenticated
   , getOrder
   , getClientOrder
   , placeOrder
+  , placeOrderBody
   , cancelOrder
   , cancelAll
   , fills
@@ -247,7 +248,16 @@ placeOrder clordid prid sd sz price po ot stp tif =
     authRequest methodPost requestPath (encodeBody body) $ API.placeOrder body
   where
     requestPath = encodeRequestPath [ordersPath]
-    body        = PlaceOrderBody clordid prid sd sz price po ot stp tif
+    body        = PlaceOrderBody clordid prid sd sz price po ot stp tif Nothing Nothing
+
+
+-- | https://docs.pro.coinbase.com/#place-a-new-order
+-- Use the underlying post body record
+placeOrderBody :: PlaceOrderBody -> CBAuthT ClientM Order
+placeOrderBody body =
+    authRequest methodPost requestPath (encodeBody body) $ API.placeOrder body
+  where
+    requestPath = encodeRequestPath [ordersPath]
 
 
 -- | https://docs.pro.coinbase.com/#cancel-an-order

--- a/src/lib/CoinbasePro/Authenticated/Orders.hs
+++ b/src/lib/CoinbasePro/Authenticated/Orders.hs
@@ -8,6 +8,7 @@ module CoinbasePro.Authenticated.Orders
   , STP (..)
   , TimeInForce (..)
   , PlaceOrderBody (..)
+  , StopLossSide (..)
 
   , statuses
   ) where
@@ -94,6 +95,17 @@ instance FromJSON ExecutedValue where
     parseJSON = withText "executed_value" $ \t ->
       return . ExecutedValue . read $ unpack t
 
+data StopLossSide = Loss | Entry
+    deriving (Eq, Ord, Show)
+
+
+instance ToHttpApiData StopLossSide where
+    toUrlPiece   = toLower . pack . show
+    toQueryParam = toLower . pack . show
+
+
+deriveJSON defaultOptions {constructorTagModifier = fmap Char.toLower} ''StopLossSide
+
 
 -- TODO: This might need to be split up into different order types.
 data Order = Order
@@ -112,6 +124,8 @@ data Order = Order
     , executedValue :: Maybe ExecutedValue
     , status        :: Status
     , settled       :: Bool
+    , stop          :: Maybe StopLossSide
+    , stopPrice     :: Maybe Price
     } deriving (Eq, Show)
 
 
@@ -119,15 +133,17 @@ deriveJSON defaultOptions {fieldLabelModifier = filterOrderFieldName . snakeCase
 
 
 data PlaceOrderBody = PlaceOrderBody
-    { bClientOid :: Maybe ClientOrderId
-    , bProductId :: ProductId
-    , bSide      :: Side
-    , bSize      :: Size
-    , bPrice     :: Price
-    , bPostOnly  :: Bool
-    , bOrderType :: Maybe OrderType
-    , bStp       :: Maybe STP
-    , bTif       :: Maybe TimeInForce
+    { bClientOid   :: Maybe ClientOrderId
+    , bProductId   :: ProductId
+    , bSide        :: Side
+    , bSize        :: Size
+    , bPrice       :: Price
+    , bPostOnly    :: Bool
+    , bOrderType   :: Maybe OrderType
+    , bStp         :: Maybe STP
+    , bTimeInForce :: Maybe TimeInForce
+    , bStop        :: Maybe StopLossSide
+    , bStopPrice   :: Maybe Price
     } deriving (Eq, Show)
 
 


### PR DESCRIPTION
This implementation of using `PlaceOrderBody` is not an ideal API. However, it was a quick way to expose an API that supports stop orders and uses a record. And it can be beneficial to have an API with as close to 1:1 correspondence with the API documentation as possible.