### PR TITLE
Bump cryptonite version bounds

### DIFF
--- a/coinbase-pro.cabal
+++ b/coinbase-pro.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d5b9be9c9bd330a927bb5d859225384c5425281c318c04f4c60b2cd03fc7e7d2
+-- hash: dbf0661dc50d070225ebb991ca629fb4e9314397426045b9f1e45f97e91ece92
 
 name:           coinbase-pro
 version:        0.9.2.1
@@ -25,7 +25,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/https://github.com/mdunnio/coinbase-pro
+  location: https://github.com/mdunnio/coinbase-pro
 
 library
   exposed-modules:
@@ -74,35 +74,35 @@ library
   hs-source-dirs:
       src/lib/
   build-depends:
-      HsOpenSSL >=0.11 && <0.12
+      HsOpenSSL ==0.11.*
     , aeson >=1.2 && <1.6
     , aeson-casing >=0.1 && <0.3
     , async >=2.1 && <2.3
     , base >=4.7 && <5
-    , binary >=0.8 && <0.9
-    , bytestring >=0.10 && <0.11
+    , binary ==0.8.*
+    , bytestring ==0.10.*
     , containers >=0.5 && <0.7
-    , cryptonite >=0.24 && <0.28
+    , cryptonite >=0.24 && <0.29
     , http-api-data >=0.3 && <0.5
     , http-client >=0.5 && <0.7
-    , http-client-tls >=0.3 && <0.4
-    , http-streams >=0.8 && <0.9
-    , http-types >=0.12 && <0.13
-    , io-streams >=1.5 && <1.6
+    , http-client-tls ==0.3.*
+    , http-streams ==0.8.*
+    , http-types ==0.12.*
+    , io-streams ==1.5.*
     , memory >=0.14 && <0.16
     , network >=2.6 && <3.2
     , servant >=0.14 && <0.19
     , servant-client >=0.14 && <0.19
     , servant-client-core >=0.14 && <0.19
-    , text >=1.2 && <1.3
+    , text ==1.2.*
     , time >=1.8 && <2.0
-    , transformers >=0.5 && <0.6
-    , unagi-streams >=0.2 && <0.3
-    , unordered-containers >=0.2 && <0.3
-    , uuid >=1.3 && <1.4
-    , vector >=0.12 && <0.13
-    , websockets >=0.12 && <0.13
-    , wuss >=1.1 && <1.2
+    , transformers ==0.5.*
+    , unagi-streams ==0.2.*
+    , unordered-containers ==0.2.*
+    , uuid ==1.3.*
+    , vector ==0.12.*
+    , websockets ==0.12.*
+    , wuss ==1.1.*
   default-language: Haskell2010
 
 executable test-request
@@ -112,36 +112,36 @@ executable test-request
   hs-source-dirs:
       src/example/request/
   build-depends:
-      HsOpenSSL >=0.11 && <0.12
+      HsOpenSSL ==0.11.*
     , aeson >=1.2 && <1.6
     , aeson-casing >=0.1 && <0.3
     , async >=2.1 && <2.3
     , base >=4.7 && <5
-    , binary >=0.8 && <0.9
-    , bytestring >=0.10 && <0.11
+    , binary ==0.8.*
+    , bytestring ==0.10.*
     , coinbase-pro
     , containers >=0.5 && <0.7
-    , cryptonite >=0.24 && <0.28
+    , cryptonite >=0.24 && <0.29
     , http-api-data >=0.3 && <0.5
     , http-client >=0.5 && <0.7
-    , http-client-tls >=0.3 && <0.4
-    , http-streams >=0.8 && <0.9
-    , http-types >=0.12 && <0.13
-    , io-streams >=1.5 && <1.6
+    , http-client-tls ==0.3.*
+    , http-streams ==0.8.*
+    , http-types ==0.12.*
+    , io-streams ==1.5.*
     , memory >=0.14 && <0.16
     , network >=2.6 && <3.2
     , servant >=0.14 && <0.19
     , servant-client >=0.14 && <0.19
     , servant-client-core >=0.14 && <0.19
-    , text >=1.2 && <1.3
+    , text ==1.2.*
     , time >=1.8 && <2.0
-    , transformers >=0.5 && <0.6
-    , unagi-streams >=0.2 && <0.3
-    , unordered-containers >=0.2 && <0.3
-    , uuid >=1.3 && <1.4
-    , vector >=0.12 && <0.13
-    , websockets >=0.12 && <0.13
-    , wuss >=1.1 && <1.2
+    , transformers ==0.5.*
+    , unagi-streams ==0.2.*
+    , unordered-containers ==0.2.*
+    , uuid ==1.3.*
+    , vector ==0.12.*
+    , websockets ==0.12.*
+    , wuss ==1.1.*
   default-language: Haskell2010
 
 executable test-stream
@@ -151,34 +151,34 @@ executable test-stream
   hs-source-dirs:
       src/example/stream/
   build-depends:
-      HsOpenSSL >=0.11 && <0.12
+      HsOpenSSL ==0.11.*
     , aeson >=1.2 && <1.6
     , aeson-casing >=0.1 && <0.3
     , async >=2.1 && <2.3
     , base >=4.7 && <5
-    , binary >=0.8 && <0.9
-    , bytestring >=0.10 && <0.11
+    , binary ==0.8.*
+    , bytestring ==0.10.*
     , coinbase-pro
     , containers >=0.5 && <0.7
-    , cryptonite >=0.24 && <0.28
+    , cryptonite >=0.24 && <0.29
     , http-api-data >=0.3 && <0.5
     , http-client >=0.5 && <0.7
-    , http-client-tls >=0.3 && <0.4
-    , http-streams >=0.8 && <0.9
-    , http-types >=0.12 && <0.13
-    , io-streams >=1.5 && <1.6
+    , http-client-tls ==0.3.*
+    , http-streams ==0.8.*
+    , http-types ==0.12.*
+    , io-streams ==1.5.*
     , memory >=0.14 && <0.16
     , network >=2.6 && <3.2
     , servant >=0.14 && <0.19
     , servant-client >=0.14 && <0.19
     , servant-client-core >=0.14 && <0.19
-    , text >=1.2 && <1.3
+    , text ==1.2.*
     , time >=1.8 && <2.0
-    , transformers >=0.5 && <0.6
-    , unagi-streams >=0.2 && <0.3
-    , unordered-containers >=0.2 && <0.3
-    , uuid >=1.3 && <1.4
-    , vector >=0.12 && <0.13
-    , websockets >=0.12 && <0.13
-    , wuss >=1.1 && <1.2
+    , transformers ==0.5.*
+    , unagi-streams ==0.2.*
+    , unordered-containers ==0.2.*
+    , uuid ==1.3.*
+    , vector ==0.12.*
+    , websockets ==0.12.*
+    , wuss ==1.1.*
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ dependencies:
   - binary               >= 0.8  && < 0.9
   - bytestring           >= 0.10 && < 0.11
   - containers           >= 0.5  && < 0.7
-  - cryptonite           >= 0.24 && < 0.28
+  - cryptonite           >= 0.24 && < 0.29
   - http-api-data        >= 0.3  && < 0.5
   - http-client          >= 0.5  && < 0.7
   - http-client-tls      >= 0.3  && < 0.4


### PR DESCRIPTION
Things still seem to compiles with this version bump. This should unbreak this lib in nixpkgs.