### PR TITLE
Add funds support for market orders and fix deposit response definition

### DIFF
--- a/src/example/request/Main.hs
+++ b/src/example/request/Main.hs
@@ -33,8 +33,8 @@ main = do
         accountHistory aid >>= liftIO . print
         fills (Just btcusd) Nothing >>= liftIO . print
         listOrders (Just [All]) (Just btcusd) >>= liftIO . print
-        placeOrder Nothing btcusd Sell (Size 0.001) (Price 99999.00) True Nothing Nothing Nothing >>= liftIO . print
-        placeOrder Nothing btcusd Buy (Size 1.0) (Price 1.00) True Nothing Nothing Nothing >>= liftIO . print
+        placeOrder Nothing btcusd Sell (Just $ Size 0.001) (Just $ Price 99999.00) (Just True) Nothing Nothing Nothing >>= liftIO . print
+        placeOrder Nothing btcusd Buy (Just $ Size 1.0) (Just $ Price 1.00) (Just True) Nothing Nothing Nothing >>= liftIO . print
         cancelAll (Just btcusd) >>= liftIO . print
   where
     accessKey  = CBAccessKey "accesskey"

--- a/src/lib/CoinbasePro/Authenticated.hs
+++ b/src/lib/CoinbasePro/Authenticated.hs
@@ -235,15 +235,15 @@ getClientOrder cloid = authRequest methodGet requestPath emptyBody $ API.getClie
 
 -- | https://docs.pro.coinbase.com/#place-a-new-order
 placeOrder :: Maybe ClientOrderId
-              -> ProductId
-              -> Side
-              -> Maybe Size
-              -> Maybe Price
-              -> Maybe Bool
-              -> Maybe OrderType
-              -> Maybe STP
-              -> Maybe TimeInForce
-              -> CBAuthT ClientM Order
+            -> ProductId
+            -> Side
+            -> Maybe Size
+            -> Maybe Price
+            -> Maybe Bool
+            -> Maybe OrderType
+            -> Maybe STP
+            -> Maybe TimeInForce
+            -> CBAuthT ClientM Order
 placeOrder clordid prid sd sz price po ot stp tif =
     authRequest methodPost requestPath (encodeBody body) $ API.placeOrder body
   where

--- a/src/lib/CoinbasePro/Authenticated.hs
+++ b/src/lib/CoinbasePro/Authenticated.hs
@@ -234,21 +234,21 @@ getClientOrder cloid = authRequest methodGet requestPath emptyBody $ API.getClie
 
 
 -- | https://docs.pro.coinbase.com/#place-a-new-order
-placeOrder :: Maybe ClientOrderId
-           -> ProductId
-           -> Side
-           -> Size
-           -> Price
-           -> Bool
-           -> Maybe OrderType
-           -> Maybe STP
-           -> Maybe TimeInForce
-           -> CBAuthT ClientM Order
+placeOrder :: Maybe ClientOrderId ->
+              ProductId ->
+              Side ->
+              Maybe Size ->
+              Maybe Price ->
+              Maybe Bool ->
+              Maybe OrderType ->
+              Maybe STP ->
+              Maybe TimeInForce ->
+              CBAuthT ClientM Order
 placeOrder clordid prid sd sz price po ot stp tif =
     authRequest methodPost requestPath (encodeBody body) $ API.placeOrder body
   where
     requestPath = encodeRequestPath [ordersPath]
-    body        = PlaceOrderBody clordid prid sd sz price po ot stp tif Nothing Nothing
+    body        = PlaceOrderBody clordid prid sd sz Nothing price po ot stp tif Nothing Nothing
 
 
 -- | https://docs.pro.coinbase.com/#place-a-new-order

--- a/src/lib/CoinbasePro/Authenticated.hs
+++ b/src/lib/CoinbasePro/Authenticated.hs
@@ -235,15 +235,15 @@ getClientOrder cloid = authRequest methodGet requestPath emptyBody $ API.getClie
 
 -- | https://docs.pro.coinbase.com/#place-a-new-order
 placeOrder :: Maybe ClientOrderId
-            -> ProductId
-            -> Side
-            -> Maybe Size
-            -> Maybe Price
-            -> Maybe Bool
-            -> Maybe OrderType
-            -> Maybe STP
-            -> Maybe TimeInForce
-            -> CBAuthT ClientM Order
+           -> ProductId
+           -> Side
+           -> Maybe Size
+           -> Maybe Price
+           -> Maybe Bool
+           -> Maybe OrderType
+           -> Maybe STP
+           -> Maybe TimeInForce
+           -> CBAuthT ClientM Order
 placeOrder clordid prid sd sz price po ot stp tif =
     authRequest methodPost requestPath (encodeBody body) $ API.placeOrder body
   where

--- a/src/lib/CoinbasePro/Authenticated.hs
+++ b/src/lib/CoinbasePro/Authenticated.hs
@@ -234,16 +234,16 @@ getClientOrder cloid = authRequest methodGet requestPath emptyBody $ API.getClie
 
 
 -- | https://docs.pro.coinbase.com/#place-a-new-order
-placeOrder :: Maybe ClientOrderId ->
-              ProductId ->
-              Side ->
-              Maybe Size ->
-              Maybe Price ->
-              Maybe Bool ->
-              Maybe OrderType ->
-              Maybe STP ->
-              Maybe TimeInForce ->
-              CBAuthT ClientM Order
+placeOrder :: Maybe ClientOrderId
+              -> ProductId
+              -> Side
+              -> Maybe Size
+              -> Maybe Price
+              -> Maybe Bool
+              -> Maybe OrderType
+              -> Maybe STP
+              -> Maybe TimeInForce
+              -> CBAuthT ClientM Order
 placeOrder clordid prid sd sz price po ot stp tif =
     authRequest methodPost requestPath (encodeBody body) $ API.placeOrder body
   where

--- a/src/lib/CoinbasePro/Authenticated/Deposit.hs
+++ b/src/lib/CoinbasePro/Authenticated/Deposit.hs
@@ -10,8 +10,8 @@ module CoinbasePro.Authenticated.Deposit
     , CryptoDepositAddress (..)
     ) where
 
-import           Data.Aeson                         (FromJSON,
-                                                     parseJSON, withObject, (.:))
+import           Data.Aeson                         (FromJSON, parseJSON,
+                                                     withObject, (.:))
 import           Data.Aeson.Casing                  (snakeCase)
 import           Data.Aeson.TH                      (defaultOptions, deriveJSON,
                                                      fieldLabelModifier)

--- a/src/lib/CoinbasePro/Authenticated/Deposit.hs
+++ b/src/lib/CoinbasePro/Authenticated/Deposit.hs
@@ -10,6 +10,8 @@ module CoinbasePro.Authenticated.Deposit
     , CryptoDepositAddress (..)
     ) where
 
+import           Data.Aeson                         (FromJSON,
+                                                     parseJSON, withObject, (.:))
 import           Data.Aeson.Casing                  (snakeCase)
 import           Data.Aeson.TH                      (defaultOptions, deriveJSON,
                                                      fieldLabelModifier)
@@ -62,9 +64,13 @@ data DepositResponse = DepositResponse
     , rPayoutAt :: UTCTime
     } deriving (Eq, Show)
 
-
-deriveJSON defaultOptions { fieldLabelModifier = snakeCase . drop 1 } ''DepositResponse
-
+instance FromJSON DepositResponse where
+    parseJSON = withObject "deposit response" $ \o ->
+        DepositResponse
+        <$> o .: "id"
+        <*> (read <$> o .: "amount")
+        <*> o .: "currency"
+        <*> o .: "payout_at"
 
 data AddressInfo = AddressInfo
     { aiAddress        :: Text

--- a/src/lib/CoinbasePro/Authenticated/Orders.hs
+++ b/src/lib/CoinbasePro/Authenticated/Orders.hs
@@ -135,18 +135,18 @@ deriveJSON defaultOptions {fieldLabelModifier = filterOrderFieldName . snakeCase
 
 
 data PlaceOrderBody = PlaceOrderBody
-    { bClientOid :: Maybe ClientOrderId
-    ,  bProductId :: ProductId
-    ,  bSide :: Side
-    ,  bSize :: Maybe Size
-    ,  bFunds :: Maybe Funds
-    ,  bPrice :: Maybe Price
-    ,  bPostOnly :: Maybe Bool
-    ,  bOrderType :: Maybe OrderType
-    ,  bStp :: Maybe STP
+    {  bClientOid   :: Maybe ClientOrderId
+    ,  bProductId   :: ProductId
+    ,  bSide        :: Side
+    ,  bSize        :: Maybe Size
+    ,  bFunds       :: Maybe Funds
+    ,  bPrice       :: Maybe Price
+    ,  bPostOnly    :: Maybe Bool
+    ,  bOrderType   :: Maybe OrderType
+    ,  bStp         :: Maybe STP
     ,  bTimeInForce :: Maybe TimeInForce
-    ,  bStop :: Maybe StopLossSide
-    ,  bStopPrice :: Maybe Price
+    ,  bStop        :: Maybe StopLossSide
+    ,  bStopPrice   :: Maybe Price
     } deriving (Eq, Show)
 
 deriveJSON defaultOptions {fieldLabelModifier = snakeCase . drop 1, omitNothingFields = True} ''PlaceOrderBody

--- a/src/lib/CoinbasePro/Authenticated/Orders.hs
+++ b/src/lib/CoinbasePro/Authenticated/Orders.hs
@@ -24,8 +24,8 @@ import           Data.Set          (Set, fromList)
 import           Data.Text         (pack, toLower, unpack)
 import           Web.HttpApiData   (ToHttpApiData (..))
 
-import           CoinbasePro.Types (ClientOrderId, CreatedAt, OrderId,
-                                    OrderType, Price, ProductId, Side, Size, Funds,
+import           CoinbasePro.Types (ClientOrderId, CreatedAt, Funds, OrderId,
+                                    OrderType, Price, ProductId, Side, Size,
                                     filterOrderFieldName)
 
 

--- a/src/lib/CoinbasePro/Authenticated/Orders.hs
+++ b/src/lib/CoinbasePro/Authenticated/Orders.hs
@@ -135,18 +135,18 @@ deriveJSON defaultOptions {fieldLabelModifier = filterOrderFieldName . snakeCase
 
 
 data PlaceOrderBody = PlaceOrderBody
-    {  bClientOid   :: Maybe ClientOrderId
-    ,  bProductId   :: ProductId
-    ,  bSide        :: Side
-    ,  bSize        :: Maybe Size
-    ,  bFunds       :: Maybe Funds
-    ,  bPrice       :: Maybe Price
-    ,  bPostOnly    :: Maybe Bool
-    ,  bOrderType   :: Maybe OrderType
-    ,  bStp         :: Maybe STP
-    ,  bTimeInForce :: Maybe TimeInForce
-    ,  bStop        :: Maybe StopLossSide
-    ,  bStopPrice   :: Maybe Price
+    { bClientOid   :: Maybe ClientOrderId
+    , bProductId   :: ProductId
+    , bSide        :: Side
+    , bSize        :: Maybe Size
+    , bFunds       :: Maybe Funds
+    , bPrice       :: Maybe Price
+    , bPostOnly    :: Maybe Bool
+    , bOrderType   :: Maybe OrderType
+    , bStp         :: Maybe STP
+    , bTimeInForce :: Maybe TimeInForce
+    , bStop        :: Maybe StopLossSide
+    , bStopPrice   :: Maybe Price
     } deriving (Eq, Show)
 
 deriveJSON defaultOptions {fieldLabelModifier = snakeCase . drop 1, omitNothingFields = True} ''PlaceOrderBody

--- a/src/lib/CoinbasePro/Authenticated/Orders.hs
+++ b/src/lib/CoinbasePro/Authenticated/Orders.hs
@@ -25,7 +25,7 @@ import           Data.Text         (pack, toLower, unpack)
 import           Web.HttpApiData   (ToHttpApiData (..))
 
 import           CoinbasePro.Types (ClientOrderId, CreatedAt, OrderId,
-                                    OrderType, Price, ProductId, Side, Size,
+                                    OrderType, Price, ProductId, Side, Size, Funds,
                                     filterOrderFieldName)
 
 
@@ -132,19 +132,21 @@ data Order = Order
 deriveJSON defaultOptions {fieldLabelModifier = filterOrderFieldName . snakeCase} ''Order
 
 
-data PlaceOrderBody = PlaceOrderBody
-    { bClientOid   :: Maybe ClientOrderId
-    , bProductId   :: ProductId
-    , bSide        :: Side
-    , bSize        :: Size
-    , bPrice       :: Price
-    , bPostOnly    :: Bool
-    , bOrderType   :: Maybe OrderType
-    , bStp         :: Maybe STP
-    , bTimeInForce :: Maybe TimeInForce
-    , bStop        :: Maybe StopLossSide
-    , bStopPrice   :: Maybe Price
-    } deriving (Eq, Show)
 
+
+data PlaceOrderBody = PlaceOrderBody
+    { bClientOid :: Maybe ClientOrderId
+    ,  bProductId :: ProductId
+    ,  bSide :: Side
+    ,  bSize :: Maybe Size
+    ,  bFunds :: Maybe Funds
+    ,  bPrice :: Maybe Price
+    ,  bPostOnly :: Maybe Bool
+    ,  bOrderType :: Maybe OrderType
+    ,  bStp :: Maybe STP
+    ,  bTimeInForce :: Maybe TimeInForce
+    ,  bStop :: Maybe StopLossSide
+    ,  bStopPrice :: Maybe Price
+    } deriving (Eq, Show)
 
 deriveJSON defaultOptions {fieldLabelModifier = snakeCase . drop 1, omitNothingFields = True} ''PlaceOrderBody

--- a/src/lib/CoinbasePro/Authenticated/Transfer.hs
+++ b/src/lib/CoinbasePro/Authenticated/Transfer.hs
@@ -5,6 +5,8 @@ module CoinbasePro.Authenticated.Transfer
     ( TransferType (..)
     , Transfer (..)
     , TransferDetails (..)
+    , WithdrawalTransfer (..)
+    , DepositTransfer (..)
     ) where
 
 import           Data.Aeson                           (FromJSON (..), ToJSON,

--- a/src/lib/CoinbasePro/Authenticated/Transfer.hs
+++ b/src/lib/CoinbasePro/Authenticated/Transfer.hs
@@ -40,7 +40,7 @@ data TransferDetails = TransferDetails
     { tId          :: Text
     , tType        :: Text
     , tCreatedAt   :: CreatedAt
-    , tCompletedAt :: UTCTime
+    , tCompletedAt :: Maybe UTCTime
     , tCanceledAt  :: Maybe UTCTime
     , tProcessedAt :: Maybe UTCTime
     , tAccountId   :: AccountId
@@ -55,7 +55,7 @@ instance FromJSON TransferDetails where
     <$> (o .: "id")
     <*> (o .: "type")
     <*> (o .: "created_at")
-    <*> (o .: "completed_at")
+    <*> (o .:? "completed_at")
     <*> (o .:? "canceled_at")
     <*> (o .:? "processed_at")
     <*> (o .: "account_id")

--- a/src/lib/CoinbasePro/Authenticated/Transfer.hs
+++ b/src/lib/CoinbasePro/Authenticated/Transfer.hs
@@ -4,6 +4,7 @@
 module CoinbasePro.Authenticated.Transfer
     ( TransferType (..)
     , Transfer (..)
+    , TransferDetails (..)
     ) where
 
 import           Data.Aeson                           (FromJSON (..), ToJSON,

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -112,7 +112,8 @@ instance FromJSON CryptoWithdrawalResponse where
     <*> (read <$> o .: "amount")
     <*> o .: "currency"
     <*> ((read <$> o .: "fee") <|> (o .: "fee"))
-    <*> (read <$> o .: "subtotal")
+    <*> ((read <$> o .: "subtotal") <|> (o .: "subtotal"))
+    
 
 
 newtype WithdrawalFeeEstimateResponse = WithdrawalFeeEstimateResponse

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -23,6 +23,7 @@ import           Data.UUID                          (UUID)
 import           CoinbasePro.Authenticated.Accounts (AccountId)
 import           CoinbasePro.Authenticated.Payment  (PaymentMethodId)
 import           Control.Applicative
+import Text.Read (readMaybe)
 
 
 data WithdrawalDetails = WithdrawalDetails
@@ -47,8 +48,8 @@ instance FromJSON WithdrawalDetails where
     <*> o .:? "coinbase_withdrawal_id"
     <*> o .:? "coinbase_transaction_id"
     <*> o .: "coinbase_payment_method_id"
-    <*> (maybe Nothing read <$> o .:? "fee")
-    <*> (maybe Nothing read <$> o .:? "subtotal")
+    <*> (maybe Nothing readMaybe <$> o .:? "fee")
+    <*> (maybe Nothing readMaybe <$> o .:? "subtotal")
 
 
 data WithdrawalRequest = WithdrawalRequest

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -112,8 +112,8 @@ instance FromJSON CryptoWithdrawalResponse where
     <$> o .: "id"
     <*> (read <$> o .: "amount")
     <*> o .: "currency"
-    <*> ((read <$> o .: "fee") <|> (o .: "fee"))
-    <*> ((read <$> o .: "subtotal") <|> (o .: "subtotal"))
+    <*> (read <$> o .: "fee")
+    <*> (read <$> o .: "subtotal")
     
 
 

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -23,19 +23,19 @@ import           Data.UUID                          (UUID)
 import           CoinbasePro.Authenticated.Accounts (AccountId)
 import           CoinbasePro.Authenticated.Payment  (PaymentMethodId)
 import           Control.Applicative
-import Text.Read (readMaybe)
+import           Text.Read                          (readMaybe)
 
 
 data WithdrawalDetails = WithdrawalDetails
-    { destinationTag        :: Maybe Text
-    , sentToAddress         :: Maybe Text
-    , coinbaseAccountId     :: Text
-    , destinationTagName    :: Maybe Text
-    , coinbaseWithdrawalId  :: Maybe Text
-    , coinbaseTransactionId :: Maybe Text
+    { destinationTag          :: Maybe Text
+    , sentToAddress           :: Maybe Text
+    , coinbaseAccountId       :: Text
+    , destinationTagName      :: Maybe Text
+    , coinbaseWithdrawalId    :: Maybe Text
+    , coinbaseTransactionId   :: Maybe Text
     , coinbasePaymentMethodId :: Text
-    , fee                   :: Maybe Double
-    , subtotal              :: Maybe Double
+    , fee                     :: Maybe Double
+    , subtotal                :: Maybe Double
     } deriving (Eq, Show)
 
 
@@ -114,7 +114,7 @@ instance FromJSON CryptoWithdrawalResponse where
     <*> o .: "currency"
     <*> ((read <$> o .: "fee") <|> (o .: "fee"))
     <*> ((read <$> o .: "subtotal") <|> (o .: "subtotal"))
-    
+
 
 
 newtype WithdrawalFeeEstimateResponse = WithdrawalFeeEstimateResponse

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -32,7 +32,7 @@ data WithdrawalDetails = WithdrawalDetails
     , destinationTagName    :: Maybe Text
     , coinbaseWithdrawalId  :: Maybe Text
     , coinbaseTransactionId :: Maybe Text
-    , cryptoPaymentMethodId :: Text
+    , coinbasePaymentMethodId :: Text
     , fee                   :: Maybe Double
     , subtotal              :: Maybe Double
     } deriving (Eq, Show)

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -22,6 +22,7 @@ import           Data.UUID                          (UUID)
 
 import           CoinbasePro.Authenticated.Accounts (AccountId)
 import           CoinbasePro.Authenticated.Payment  (PaymentMethodId)
+import           Control.Applicative
 
 
 data WithdrawalDetails = WithdrawalDetails
@@ -110,7 +111,7 @@ instance FromJSON CryptoWithdrawalResponse where
     <$> o .: "id"
     <*> (read <$> o .: "amount")
     <*> o .: "currency"
-    <*> (read <$> o .: "fee")
+    <*> ((read <$> o .: "fee") <|> (o .: "fee"))
     <*> (read <$> o .: "subtotal")
 
 

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -112,8 +112,8 @@ instance FromJSON CryptoWithdrawalResponse where
     <$> o .: "id"
     <*> (read <$> o .: "amount")
     <*> o .: "currency"
-    <*> (read <$> o .: "fee")
-    <*> (read <$> o .: "subtotal")
+    <*> ((read <$> o .: "fee") <|> (o .: "fee"))
+    <*> ((read <$> o .: "subtotal") <|> (o .: "subtotal"))
     
 
 

--- a/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
+++ b/src/lib/CoinbasePro/Authenticated/Withdrawal.hs
@@ -31,7 +31,7 @@ data WithdrawalDetails = WithdrawalDetails
     , coinbaseAccountId     :: Text
     , destinationTagName    :: Maybe Text
     , coinbaseWithdrawalId  :: Maybe Text
-    , coinbaseTransactionId :: Text
+    , coinbaseTransactionId :: Maybe Text
     , cryptoPaymentMethodId :: Text
     , fee                   :: Maybe Double
     , subtotal              :: Maybe Double
@@ -45,7 +45,7 @@ instance FromJSON WithdrawalDetails where
     <*> o .: "coinbase_account_id"
     <*> o .:? "destination_tag_name"
     <*> o .:? "coinbase_withdrawal_id"
-    <*> o .: "coinbase_transaction_id"
+    <*> o .:? "coinbase_transaction_id"
     <*> o .: "coinbase_payment_method_id"
     <*> (maybe Nothing read <$> o .:? "fee")
     <*> (maybe Nothing read <$> o .:? "subtotal")

--- a/src/lib/CoinbasePro/Types.hs
+++ b/src/lib/CoinbasePro/Types.hs
@@ -15,7 +15,7 @@ module CoinbasePro.Types
     , Size (..)
     , Volume (..)
     , TradeId (..)
-    , Funds
+    , Funds (..)
     , OrderType (..)
     , CreatedAt (..)
     , Candle (..)


### PR DESCRIPTION
https://docs.pro.coinbase.com/#place-a-new-order

Wanted to add support for funds in market orders so that you can say the amount of crypto you want in USD for instance, rather than having to pass in the amount of the crypto you want (since the price can fluctuate).

The deposit response from coinbase pro is a string representing a number, not a double, so made that fix by changing the FromJSON instance. https://docs.pro.coinbase.com/#payment-method

The crypto withdrawal API response shows the fee and subtotal as strings in the API response (https://docs.pro.coinbase.com/#crypto) but I was receiving floats when actually running them so I added an alternative parser that works since I'm not sure which one is supposed to be correct.

I didn't make too many changes to the `placeOrder` function as I'm not sure how much of the underlying API it's supposed to support, as all the parameters available in coinbase's docs (in the link above) are not available in that function, so I tried to make minimal changes and directly use the `placeOrderBody` function for my usage of this library.

This was tested by executing an actual trade and transfer.

Viewing the fee and subtotal from a `WithdrawalTransfer` crashes at runtime unless `readMaybe` is used in place of `read`.

Edit:
I see that coinbase pro has completely changed with a new website. This PR does not account for that, but the changes in this PR do still work.