### PR TITLE
Update dependencies for GHC 9.8

### DIFF
--- a/coinbase-pro.cabal
+++ b/coinbase-pro.cabal
@@ -79,7 +79,7 @@ library
     , async >=2.1 && <2.3
     , base >=4.7 && <5
     , binary ==0.8.*
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , containers >=0.5 && <0.7
     , cryptonite >=0.24 && <0.31
     , exceptions >=0.4 && <1.0
@@ -96,14 +96,14 @@ library
     , servant-client-core >=0.14 && <0.21
     , tasty >=1.2.2
     , tasty-hunit >=0.10
-    , text ==1.2.* || ==2.0.*
+    , text >=1.2 && <1.3 || >=2.0 && <2.2
     , time >=1.8 && <2.0
     , transformers >=0.5 && <0.7
     , unagi-streams ==0.2.*
     , unordered-containers ==0.2.*
     , uuid ==1.3.*
     , vector >=0.12 && <0.14
-    , websockets ==0.12.*
+    , websockets >=0.12 && <0.14
     , wuss >=1.1 && <3
   default-language: Haskell2010
 
@@ -120,7 +120,7 @@ executable test-request
     , async >=2.1 && <2.3
     , base >=4.7 && <5
     , binary ==0.8.*
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , coinbase-pro
     , containers >=0.5 && <0.7
     , cryptonite >=0.24 && <0.31
@@ -138,14 +138,14 @@ executable test-request
     , servant-client-core >=0.14 && <0.21
     , tasty >=1.2.2
     , tasty-hunit >=0.10
-    , text ==1.2.* || ==2.0.*
+    , text >=1.2 && <1.3 || >=2.0 && <2.2
     , time >=1.8 && <2.0
     , transformers >=0.5 && <0.7
     , unagi-streams ==0.2.*
     , unordered-containers ==0.2.*
     , uuid ==1.3.*
     , vector >=0.12 && <0.14
-    , websockets ==0.12.*
+    , websockets >=0.12 && <0.14
     , wuss >=1.1 && <3
   default-language: Haskell2010
 
@@ -162,7 +162,7 @@ executable test-stream
     , async >=2.1 && <2.3
     , base >=4.7 && <5
     , binary ==0.8.*
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , coinbase-pro
     , containers >=0.5 && <0.7
     , cryptonite >=0.24 && <0.31
@@ -180,14 +180,14 @@ executable test-stream
     , servant-client-core >=0.14 && <0.21
     , tasty >=1.2.2
     , tasty-hunit >=0.10
-    , text ==1.2.* || ==2.0.*
+    , text >=1.2 && <1.3 || >=2.0 && <2.2
     , time >=1.8 && <2.0
     , transformers >=0.5 && <0.7
     , unagi-streams ==0.2.*
     , unordered-containers ==0.2.*
     , uuid ==1.3.*
     , vector >=0.12 && <0.14
-    , websockets ==0.12.*
+    , websockets >=0.12 && <0.14
     , wuss >=1.1 && <3
   default-language: Haskell2010
 
@@ -205,7 +205,7 @@ test-suite coinbase-pro-test
     , async >=2.1 && <2.3
     , base >=4.7 && <5
     , binary ==0.8.*
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , coinbase-pro
     , containers >=0.5 && <0.7
     , cryptonite >=0.24 && <0.31
@@ -223,13 +223,13 @@ test-suite coinbase-pro-test
     , servant-client-core >=0.14 && <0.21
     , tasty >=1.2.2
     , tasty-hunit >=0.10
-    , text ==1.2.* || ==2.0.*
+    , text >=1.2 && <1.3 || >=2.0 && <2.2
     , time >=1.8 && <2.0
     , transformers >=0.5 && <0.7
     , unagi-streams ==0.2.*
     , unordered-containers ==0.2.*
     , uuid ==1.3.*
     , vector >=0.12 && <0.14
-    , websockets ==0.12.*
+    , websockets >=0.12 && <0.14
     , wuss >=1.1 && <3
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -22,35 +22,35 @@ github: mdunnio/coinbase-pro
 dependencies:
   - base                 >= 4.7   && < 5
   - HsOpenSSL            >= 0.11  && < 0.12
-  - aeson                >= 1.2   && < 2.1
+  - aeson                >= 1.2   && < 2.2
   - aeson-casing         >= 0.1   && < 0.3
   - async                >= 2.1   && < 2.3
   - binary               >= 0.8   && < 0.9
-  - bytestring           >= 0.10  && < 0.12
+  - bytestring           >= 0.10  && < 0.13
   - containers           >= 0.5   && < 0.7
   - cryptonite           >= 0.24  && < 0.31
   - exceptions           >= 0.4   && < 1.0
-  - http-api-data        >= 0.3   && < 0.5
+  - http-api-data        >= 0.3   && < 0.6
   - http-client          >= 0.5   && < 0.8
   - http-client-tls      >= 0.3   && < 0.4
   - http-streams         >= 0.8   && < 0.9
   - http-types           >= 0.12  && < 0.13
   - io-streams           >= 1.5   && < 1.6
-  - memory               >= 0.14  && < 0.18
+  - memory               >= 0.14  && < 0.19
   - network              >= 2.6   && < 3.2
-  - servant              >= 0.14  && < 0.20
-  - servant-client       >= 0.14  && < 0.20
-  - servant-client-core  >= 0.14  && < 0.20
+  - servant              >= 0.14  && < 0.21
+  - servant-client       >= 0.14  && < 0.21
+  - servant-client-core  >= 0.14  && < 0.21
   - tasty                >= 1.2.2
   - tasty-hunit          >= 0.10
-  - text                 >= 1.2   && < 1.3
+  - text                 >= 1.2   && < 1.3 || >= 2.0 && < 2.2
   - time                 >= 1.8   && < 2.0
-  - transformers         >= 0.5   && < 0.6
+  - transformers         >= 0.5   && < 0.7
   - unagi-streams        >= 0.2   && < 0.3
   - unordered-containers >= 0.2   && < 0.3
   - uuid                 >= 1.3   && < 1.4
-  - vector               >= 0.12  && < 0.13
-  - websockets           >= 0.12  && < 0.13
+  - vector               >= 0.12  && < 0.14
+  - websockets           >= 0.12  && < 0.14
   - wuss                 >= 1.1   && < 3
 
 library:


### PR DESCRIPTION
@mdunnio
Builds and tests fine.

Please consider making a new release with the bumped dependencies. It would make packaging on Arch much easier.